### PR TITLE
Added 'text-align' to primary styles

### DIFF
--- a/jquery.caretposition.js
+++ b/jquery.caretposition.js
@@ -14,7 +14,7 @@ $(function() {
 			'borderLeftColor', 'borderTopColor', 'borderBottomColor', 'borderRightColor',
 			'borderLeftStyle', 'borderTopStyle', 'borderBottomStyle', 'borderRightStyle',
 			'borderLeftWidth', 'borderTopWidth', 'borderBottomWidth', 'borderRightWidth',
-			'line-height', 'outline'],
+			'line-height', 'outline', 'text-align'],
 
 		specificStyle: {
 			'word-wrap': 'break-word',


### PR DESCRIPTION
The text-align property of the simulated textarea can be different than that of the textarea that is being simulated. This can cause the calculated caret position to be off by a significant degree. Adding text-align to the primary styles makes sure that the property is the same on both and fixes the issue.
