### PR TITLE
Replace token value with actual token entered

### DIFF
--- a/jquery.sew.js
+++ b/jquery.sew.js
@@ -93,7 +93,10 @@
 
 		var fullStuff = this.getText();
 		var val = fullStuff.substring(0, startpos);
-		val = val.replace(this.expression, '$1' + this.options.token + replacement);
+
+        var tokenEntered = val.match(new RegExp(this.options.token));
+
+		val = val.replace(this.expression, '$1' + tokenEntered[0] + replacement);
 
 		var posfix = fullStuff.substring(startpos, fullStuff.length);
 		var separator = posfix.match(/^\s/) ? '' : ' ';


### PR DESCRIPTION
It was observed that the token can contain regex string and it would be detected without problem. However, if one were to use any type of regex syntax in the token string it would replace the actual entered text for that token. 

ex:
if the token was '[-=+]' and the user entered any of the values defined by the regex (+, =, or -) the list would come up, as expected, but when a value was chosen the token the the user entered would be replaced with '[-+=]'.

This change extracts the imputed token using the original regex, then it uses that instead.
